### PR TITLE
Refactor ItemWin.w to use Business Entity pattern

### DIFF
--- a/src/ItemWin.w
+++ b/src/ItemWin.w
@@ -1,8 +1,5 @@
 &ANALYZE-SUSPEND _VERSION-NUMBER AB_v10r12 GUI
 &ANALYZE-RESUME
-/* Connected Databases 
-          sports           PROGRESS
-*/
 &Scoped-define WINDOW-NAME C-Win
 &ANALYZE-SUSPEND _UIB-CODE-BLOCK _CUSTOM _DEFINITIONS C-Win 
 /*------------------------------------------------------------------------
@@ -25,6 +22,10 @@
 /*          This .W file was created with the Progress AppBuilder.      */
 /*----------------------------------------------------------------------*/
 
+/* Include business entity classes */
+USING business.ItemEntity FROM PROPATH.
+USING business.EntityFactory FROM PROPATH.
+
 /* Create an unnamed pool to store all the widgets created 
      by this procedure. This is a good default which assures
      that this procedure's triggers and internal procedures 
@@ -39,6 +40,9 @@ CREATE WIDGET-POOL.
 
 /* Local Variable Definitions ---                                       */
 
+/* Include dataset definitions */
+{business/ItemDataset.i}
+
 /* _UIB-CODE-BLOCK-END */
 &ANALYZE-RESUME
 
@@ -52,16 +56,6 @@ CREATE WIDGET-POOL.
 
 /* Name of designated FRAME-NAME and/or first browse and/or first query */
 &Scoped-define FRAME-NAME DEFAULT-FRAME
-
-/* Internal Tables (found by Frame, Query & Browse Queries)             */
-&Scoped-define INTERNAL-TABLES Item
-
-/* Definitions for FRAME DEFAULT-FRAME                                  */
-&Scoped-define QUERY-STRING-DEFAULT-FRAME FOR EACH Item SHARE-LOCK
-&Scoped-define OPEN-QUERY-DEFAULT-FRAME OPEN QUERY DEFAULT-FRAME FOR EACH Item SHARE-LOCK.
-&Scoped-define TABLES-IN-QUERY-DEFAULT-FRAME Item
-&Scoped-define FIRST-TABLE-IN-QUERY-DEFAULT-FRAME Item
-
 
 /* Standard List Definitions                                            */
 &Scoped-Define ENABLED-OBJECTS FILL-IN_ItemNum FILL-IN_Price BUTTON-4 ~
@@ -100,11 +94,6 @@ DEFINE VARIABLE FILL-IN_Price AS DECIMAL FORMAT "->,>>>,>>9.99" INITIAL 0
      VIEW-AS FILL-IN 
      SIZE 14 BY 1 NO-UNDO.
 
-/* Query definitions                                                    */
-&ANALYZE-SUSPEND
-DEFINE QUERY DEFAULT-FRAME FOR 
-      Item SCROLLING.
-&ANALYZE-RESUME
 
 /* ************************  Frame Definitions  *********************** */
 
@@ -172,20 +161,6 @@ THEN C-Win:HIDDEN = no.
 /* _RUN-TIME-ATTRIBUTES-END */
 &ANALYZE-RESUME
 
-
-/* Setting information for Queries and Browse Widgets fields            */
-
-&ANALYZE-SUSPEND _QUERY-BLOCK FRAME DEFAULT-FRAME
-/* Query rebuild information for FRAME DEFAULT-FRAME
-     _TblList          = "sports.Item"
-     _Query            is OPENED
-*/  /* FRAME DEFAULT-FRAME */
-&ANALYZE-RESUME
-
- 
-
-
-
 /* ************************  Control Triggers  ************************ */
 
 &Scoped-define SELF-NAME C-Win
@@ -218,16 +193,23 @@ END.
 &ANALYZE-SUSPEND _UIB-CODE-BLOCK _CONTROL BUTTON-3 C-Win
 ON CHOOSE OF BUTTON-3 IN FRAME DEFAULT-FRAME /* Get Item */
 DO:
-  ASSIGN FILL-IN_ItemNum. 
-  FIND FIRST Item WHERE Item.ItemNum = INTEGER(FILL-IN_ItemNum) NO-LOCK NO-ERROR.
-  IF AVAILABLE Item THEN
-  DO:
-     FILL-IN_Price = Item.Price.
-     DISPLAY FILL-IN_Price WITH FRAME {&frame-name}.
+  VAR INTEGER iItemNum              = INTEGER(FILL-IN_ItemNum:screen-value).
+  VAR EntityFactory objFactory      = EntityFactory:GetInstance().
+  VAR ItemEntity objItemEntity      = objFactory:GetItemEntity().
+  VAR LOGICAL lItemFound            = objItemEntity:GetItemByNumber(iItemNum, OUTPUT DATASET dsItem).
+  
+  /* Update the UI based on results */
+  IF lItemFound THEN DO:
+    /* Find the item record in the temp-table */
+    FIND FIRST ttItem.
+    IF AVAILABLE ttItem THEN DO:
+      /* Set the price field and display it */
+      FILL-IN_Price = ttItem.Price.
+      DISPLAY FILL-IN_Price WITH FRAME {&frame-name}.
+    END.
   END.
-  ELSE
-     MESSAGE 'Item not found' VIEW-AS ALERT-BOX.
-
+  ELSE 
+    MESSAGE "Item not found" VIEW-AS ALERT-BOX.
 END.
 
 /* _UIB-CODE-BLOCK-END */
@@ -238,28 +220,39 @@ END.
 &ANALYZE-SUSPEND _UIB-CODE-BLOCK _CONTROL BUTTON-4 C-Win
 ON CHOOSE OF BUTTON-4 IN FRAME DEFAULT-FRAME /* Save */
 DO:
-  VAR DECIMAL dTotal.
-  FIND FIRST Item WHERE Item.ItemNum = INTEGER(FILL-IN_ItemNum) EXCLUSIVE-LOCK NO-ERROR.
-  IF AVAILABLE Item THEN
-  DO:
-     ASSIGN FILL-IN_Price.
-     IF FILL-IN_Price = 0 THEN
-     DO:
-         MESSAGE 'Price cannot be empty' VIEW-AS ALERT-BOX.
-         RETURN NO-APPLY. 
-     END.
-     dTotal = Item.OnHand * FILL-IN_Price.
-     IF dTotal > 6000 THEN
-     DO:
-         MESSAGE 'Total value onhand will be ' dTotal 
-                 ', should not be larger than 6000' VIEW-AS ALERT-BOX.
-         RETURN NO-APPLY.
-     END.
-     Item.Price = FILL-IN_Price.    
+  VAR INTEGER iItemNum              = INTEGER(FILL-IN_ItemNum:screen-value).
+  VAR EntityFactory objFactory      = EntityFactory:GetInstance().
+  VAR ItemEntity objItemEntity      = objFactory:GetItemEntity().
+  VAR LOGICAL lItemFound            = objItemEntity:GetItemByNumber(iItemNum, OUTPUT DATASET dsItem).
+  VAR CHARACTER cErrorMessage       = "".
+  VAR LOGICAL isValid               = TRUE.
+  
+  /* Get form data */
+  ASSIGN FILL-IN_Price.
+  
+  IF lItemFound THEN DO:
+    /* Find the item record in the temp-table */
+    FIND FIRST ttItem NO-ERROR.
+    IF AVAILABLE ttItem THEN DO:
+      /* Enable change tracking */
+      TEMP-TABLE ttItem:TRACKING-CHANGES = TRUE.
+      
+      /* Update the price */
+      ttItem.Price = FILL-IN_Price.
+      
+      /* Validate the data */
+      isValid = objItemEntity:ValidateItem(DATASET dsItem BY-REFERENCE, OUTPUT cErrorMessage).
+      
+      IF isValid THEN DO:
+        /* Save changes if the data is valid */
+        objItemEntity:UpdateItem(DATASET dsItem BY-REFERENCE).
+      END.
+      ELSE
+        MESSAGE cErrorMessage VIEW-AS ALERT-BOX.
+    END.
   END.
   ELSE
-     MESSAGE 'Item not found' VIEW-AS ALERT-BOX.
-
+    MESSAGE "Item not found" VIEW-AS ALERT-BOX.
 END.
 
 /* _UIB-CODE-BLOCK-END */
@@ -331,14 +324,10 @@ PROCEDURE enable_UI :
                These statements here are based on the "Other 
                Settings" section of the widget Property Sheets.
 ------------------------------------------------------------------------------*/
-
-  {&OPEN-QUERY-DEFAULT-FRAME}
-  GET FIRST DEFAULT-FRAME.
   DISPLAY FILL-IN_ItemNum FILL-IN_Price 
       WITH FRAME DEFAULT-FRAME IN WINDOW C-Win.
   ENABLE FILL-IN_ItemNum FILL-IN_Price BUTTON-4 BUTTON-3 
       WITH FRAME DEFAULT-FRAME IN WINDOW C-Win.
-  {&OPEN-BROWSERS-IN-QUERY-DEFAULT-FRAME}
   VIEW C-Win.
 END PROCEDURE.
 

--- a/src/business/EntityFactory.cls
+++ b/src/business/EntityFactory.cls
@@ -10,6 +10,7 @@
 
 USING Progress.Lang.*.
 USING business.CustomerEntity.
+USING business.ItemEntity.
 USING business.EntityFactory.
 
 BLOCK-LEVEL ON ERROR UNDO, THROW.
@@ -21,6 +22,7 @@ CLASS business.EntityFactory USE-WIDGET-POOL:
     
     /* Singleton instances of business entities */
     VAR PRIVATE CustomerEntity objCustomerEntityInstance.
+    VAR PRIVATE ItemEntity objItemEntityInstance.
     
     /*------------------------------------------------------------------------------
      Purpose: Private constructor to prevent direct instantiation
@@ -51,6 +53,17 @@ CLASS business.EntityFactory USE-WIDGET-POOL:
         
         RETURN objCustomerEntityInstance.
     END METHOD.
+    
+    /*------------------------------------------------------------------------------
+     Purpose: Get the singleton instance of ItemEntity
+     Notes:
+    ------------------------------------------------------------------------------*/
+    METHOD PUBLIC ItemEntity GetItemEntity():
+        IF objItemEntityInstance = ? THEN
+            objItemEntityInstance = NEW ItemEntity().
+        
+        RETURN objItemEntityInstance.
+    END METHOD.
         
     /*------------------------------------------------------------------------------
      Purpose: Reset all entity instances (for testing or cleanup)
@@ -60,7 +73,12 @@ CLASS business.EntityFactory USE-WIDGET-POOL:
         IF VALID-OBJECT(objCustomerEntityInstance) THEN
             DELETE OBJECT objCustomerEntityInstance.
         
-        objCustomerEntityInstance = ?.    
+        objCustomerEntityInstance = ?.
+        
+        IF VALID-OBJECT(objItemEntityInstance) THEN
+            DELETE OBJECT objItemEntityInstance.
+        
+        objItemEntityInstance = ?.
     END METHOD.
     
 END CLASS.


### PR DESCRIPTION
## Summary

Refactors `ItemWin.w` to remove legacy fat-client code (direct database access) and adopt the Business Entity architecture pattern as documented in `doc/business-entity-pattern.md`.

## Changes

### `src/ItemWin.w`
- **Removed** direct `FIND FIRST Item` database access from both "Get Item" and "Save" button triggers
- **Added** `USING` statements for `business.ItemEntity` and `business.EntityFactory`
- **Added** `{business/ItemDataset.i}` include for temp-table/dataset definitions
- **Refactored** "Get Item" trigger to use `EntityFactory:GetInstance()` → `GetItemEntity()` → `GetItemByNumber()` and read from `ttItem` temp-table
- **Refactored** "Save" trigger to use the entity pattern with change tracking (`TRACKING-CHANGES`), validation via `ValidateItem()`, and persistence via `UpdateItem()`
- **Removed** legacy query definitions (`QUERY-STRING-DEFAULT-FRAME`, `OPEN-QUERY-DEFAULT-FRAME`, `INTERNAL-TABLES`, etc.) since data access is now through the entity layer
- **Cleaned up** `enable_UI` to remove the database query open/get statements

### `src/business/EntityFactory.cls`
- **Added** `USING business.ItemEntity` import
- **Added** `objItemEntityInstance` private variable for singleton ItemEntity
- **Added** `GetItemEntity()` method with lazy initialization
- **Updated** `ResetInstances()` to clean up the ItemEntity instance

## Pattern Applied

Follows the documented refactoring steps (Steps 4-6) from the business entity pattern guide:
1. ✅ Dataset definition already exists (`ItemDataset.i`)
2. ✅ Business entity already exists (`ItemEntity.cls`)
3. ✅ Entity added to factory (this PR)
4. ✅ UI code refactored to use entity layer (this PR)
5. ✅ Validation delegated to `ItemEntity.ValidateItem()`

Fixes #1